### PR TITLE
Changed the feature version qualifier

### DIFF
--- a/net.dreiucker.DecDescLanguage.UpdateSite/site.xml
+++ b/net.dreiucker.DecDescLanguage.UpdateSite/site.xml
@@ -1,13 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/net.dreiucker.DecDescLanguageFeature_1.0.0.201608031116.jar" id="net.dreiucker.DecDescLanguageFeature" version="1.0.0.201608031116">
+   <feature url="features/net.dreiucker.DecDescLanguage.javadocFeature_1.0.0.jar" id="net.dreiucker.DecDescLanguage.javadocFeature" version="1.0.0">
       <category name="net.dreiucker.DecDescLanguage"/>
    </feature>
-   <feature url="features/net.dreiucker.DecDescLanguage.tracebilityFeature_1.0.0.201608031116.jar" id="net.dreiucker.DecDescLanguage.tracebilityFeature" version="1.0.0.201608031116">
+   <feature url="features/net.dreiucker.DecDescLanguage.tracebilityFeature_1.0.0.jar" id="net.dreiucker.DecDescLanguage.tracebilityFeature" version="1.0.0">
       <category name="net.dreiucker.DecDescLanguage"/>
    </feature>
-   <feature url="features/net.dreiucker.DecDescLanguage.javadocFeature_1.0.0.201608031116.jar" id="net.dreiucker.DecDescLanguage.javadocFeature" version="1.0.0.201608031116">
+   <feature url="features/net.dreiucker.DecDescLanguageFeature_1.0.0.jar" id="net.dreiucker.DecDescLanguageFeature" version="1.0.0">
       <category name="net.dreiucker.DecDescLanguage"/>
    </feature>
-   <category-def name="net.dreiucker.DecDescLanguage" label="Decision Description Language"/>
+   <category-def name="net.dreiucker.DecDescLanguage" label="Decision Description Language">
+      <description>
+         The Decision Description Language provides GUI and modeling support for documenting decisions and referencing requirements.
+      </description>
+   </category-def>
 </site>

--- a/net.dreiucker.DecDescLanguage.javadocFeature/feature.xml
+++ b/net.dreiucker.DecDescLanguage.javadocFeature/feature.xml
@@ -2,18 +2,18 @@
 <feature
       id="net.dreiucker.DecDescLanguage.javadocFeature"
       label="Javadoc Extension for DDL"
-      version="1.0.0.qualifier">
+      version="1.0.0">
 
    <description url="https://github.com/MarkDrei/DecDescLang">
       Provides extensions to the javadoc implementation to reference both decisions (from DDL) and requirements (from RMF / ProR).
    </description>
 
    <copyright url="http://www.example.com/copyright">
-      [Enter Copyright Description here.]
+      [Enter Copyright Description for net.dreiucker.DecDescLangugage.javadocFeature here.]
    </copyright>
 
    <license url="http://www.example.com/license">
-      [Enter License Description here.]
+      [Enter License Description for net.dreiucker.DecDescLangugage.javadocFeature here.]
    </license>
 
    <requires>

--- a/net.dreiucker.DecDescLanguage.tracebilityFeature/feature.xml
+++ b/net.dreiucker.DecDescLanguage.tracebilityFeature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="net.dreiucker.DecDescLanguage.tracebilityFeature"
       label="Tracebility Matrix for DDL"
-      version="1.0.0.qualifier">
+      version="1.0.0">
 
    <description url="https://github.com/MarkDrei/DecDescLang">
       The Tracebility Matrix view which supports the Decision Description Language.
@@ -10,11 +10,11 @@ This view provides a matrix which maps the decisions to the requirements that ar
    </description>
 
    <copyright url="http://www.example.com/copyright">
-      [Enter Copyright Description here.]
+      [Enter Copyright Description for net.dreiucker.DecDescLangugage.tracebilityFeature here.]
    </copyright>
 
    <license url="http://www.example.com/license">
-      [Enter License Description here.]
+      [Enter License Description for net.dreiucker.DecDescLangugage.tracebilityFeature here.]
    </license>
 
    <requires>

--- a/net.dreiucker.DecDescLanguageFeature/feature.xml
+++ b/net.dreiucker.DecDescLanguageFeature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="net.dreiucker.DecDescLanguageFeature"
       label="Decision Description Language"
-      version="1.0.0.qualifier">
+      version="1.0.0">
 
    <description url="https://github.com/MarkDrei/DecDescLang">
       The core of the Decision Description Language.
@@ -10,11 +10,11 @@ Provides the model and user interfaces to for documenting decisions.
    </description>
 
    <copyright url="http://www.example.com/copyright">
-      [Enter Copyright Description here.]
+      [Enter Copyright Description for net.dreiucker.DecDescLangugageFeature here.]
    </copyright>
 
    <license url="http://www.example.com/license">
-      [Enter License Description here.]
+      [Enter License Description for net.dreiucker.DecDescLangugageFeature here.]
    </license>
 
    <plugin


### PR DESCRIPTION
Originally this included the qualifier (aka date+time) which somehow
messed up the update site: The description etc was not shown, it 
turned out the content.xml was not updated but new entries were added
which shadowed the updated ones.
